### PR TITLE
Fix bug: PyQuery argument with encoding declaration.

### DIFF
--- a/libs/response.py
+++ b/libs/response.py
@@ -123,7 +123,7 @@ class Response(object):
         """Returns a PyQuery object of a request's content"""
         if hasattr(self, '_doc'):
             return self._doc
-        doc = self._doc = PyQuery(self.text or self.content)
+        doc = self._doc = PyQuery(self.content)
         doc.make_links_absolute(self.url)
         return doc
 


### PR DESCRIPTION
http://stackoverflow.com/questions/25023237/html-scraping-using-lxml-and-requests-gives-a-unicode-error
