### PR TITLE
Add svg badges to the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-pyspider [![Build Status](https://travis-ci.org/binux/pyspider.png?branch=master)](https://travis-ci.org/binux/pyspider) [![Coverage Status](https://coveralls.io/repos/binux/pyspider/badge.png)](https://coveralls.io/r/binux/pyspider)
+pyspider [![Build Status](https://travis-ci.org/binux/pyspider.svg?branch=master)](https://travis-ci.org/binux/pyspider) [![Coverage Status](https://img.shields.io/coveralls/binux/pyspider.svg?branch=master)](https://coveralls.io/r/binux/pyspider)
 ========
 
 A Powerful Spider System in Python. [Try It Now!](http://demo.pyspider.org/)


### PR DESCRIPTION
Hello there and thanks for making this available.

Just an extremely minor pull request here. Both coveralls and travis offers their badges in svg, which looks a lot better on both regular screen and (especially) on mobile. So this pull request swaps the badges with the svg ones.

If that is of interest to you, here you are. If not, no biggie.

Thanks again, have a great day!
