### PR TITLE
Add hint for database type config

### DIFF
--- a/docs/Command-Line.md
+++ b/docs/Command-Line.md
@@ -57,6 +57,8 @@ sqlalchemy:
     more: http://docs.sqlalchemy.org/en/rel_0_9/core/engines.html
 ```
 
+**type** should be one of `taskdb`, `projectdb`, `resultdb`.
+
 #### --amqp-url
 
 See [https://www.rabbitmq.com/uri-spec.html](https://www.rabbitmq.com/uri-spec.html)

--- a/pyspider/database/__init__.py
+++ b/pyspider/database/__init__.py
@@ -124,6 +124,7 @@ def connect_database(url):
             from .sqlalchemy.resultdb import ResultDB
             return ResultDB(url)
         else:
-            raise Exception('unknow database type: %s' % dbtype)
+            raise Exception('unknow database type: %s, '
+                            'type should be one of ["taskdb", "projectdb", "resultdb"]' % dbtype)
     else:
         raise Exception('unknow engine: %s' % engine)


### PR DESCRIPTION
When trying to use a custom db config following the document. Newbee like me may get confused when hitting **Exception("unknow database type: type)**.

So I added a hint message.