### PR TITLE
Fix bug: Precision for Float column which stores timestamp is too small

### DIFF
--- a/pyspider/database/sqlalchemy/projectdb.py
+++ b/pyspider/database/sqlalchemy/projectdb.py
@@ -32,7 +32,7 @@ class ProjectDB(BaseProjectDB):
                            Column('comments', String(1024)),
                            Column('rate', Float(11)),
                            Column('burst', Float(11)),
-                           Column('updatetime', Float(16))
+                           Column('updatetime', Float(32))
                            )
         self.engine = create_engine(url, convert_unicode=True)
         self.table.create(self.engine, checkfirst=True)

--- a/pyspider/database/sqlalchemy/resultdb.py
+++ b/pyspider/database/sqlalchemy/resultdb.py
@@ -30,7 +30,7 @@ class ResultDB(SplitTableMixin, BaseResultDB):
                            Column('taskid', String(64), primary_key=True, nullable=False),
                            Column('url', String(1024)),
                            Column('result', LargeBinary),
-                           Column('updatetime', Float(16))
+                           Column('updatetime', Float(32))
                            )
         self.engine = create_engine(url, convert_unicode=True)
 

--- a/pyspider/database/sqlalchemy/taskdb.py
+++ b/pyspider/database/sqlalchemy/taskdb.py
@@ -35,8 +35,8 @@ class TaskDB(SplitTableMixin, BaseTaskDB):
                            Column('fetch', LargeBinary),
                            Column('process', LargeBinary),
                            Column('track', LargeBinary),
-                           Column('lastcrawltime', Float(16)),
-                           Column('updatetime', Float(16)),
+                           Column('lastcrawltime', Float(32)),
+                           Column('updatetime', Float(32)),
                            )
         self.engine = create_engine(url, convert_unicode=True)
 


### PR DESCRIPTION
Float(16) if not precise enough for storing unix timestamp, this may cause various bugs.
See my script for testing:

```python
# -*- coding: utf-8 -*-
import time
from sqlalchemy import create_engine
from sqlalchemy import Column, Float, MetaData, Table

echo = False

engines = (
    ('postgresql', create_engine('postgresql://DB_CONFIG', echo=echo)),
    ('mysql', create_engine('mysql://DB_CONFIG', echo=echo)),
    ('sqlite', create_engine('sqlite://', echo=echo)),
)

meta_data = MetaData()

test = Table(
    'test', meta_data,
    Column('col16', Float(precision=16)),
    Column('col32', Float(precision=32)),
)

for engine_type, engine in engines:
    print 'Engine:', engine_type
    meta_data.drop_all(engine)
    meta_data.create_all(engine)

    now = time.time()
    print 'Now:', now
    engine.execute('insert into test values (%s, %s)' % (now, now))

    for each in engine.execute(test.select()):
        print 'Float(16): %f Float(32): %f' % tuple(each)

    print 
```

Output:

```
Engine: postgresql
Now: 1421572566.87
Float(16): 1421570000.000000 Float(32): 1421572566.870000

Engine: mysql
Now: 1421572566.9
Float(16): 1421570000.000000 Float(32): 1421572566.900000

Engine: sqlite
Now: 1421572566.9
Float(16): 1421572566.900000 Float(32): 1421572566.900000
```

Only `sqlite` can give the right result.