### PR TITLE
Update scheduler.py

### DIFF
--- a/pyspider/scheduler/scheduler.py
+++ b/pyspider/scheduler/scheduler.py
@@ -574,7 +574,7 @@ class Scheduler(object):
         schedule_age = _schedule.get('age', self.default_schedule['age'])
         if _schedule.get('itag') and _schedule['itag'] != old_schedule.get('itag'):
             restart = True
-        elif schedule_age >= 0 and schedule_age + (old_task['lastcrawltime'] or 0) < now:
+        elif 'lastcrawltime' in old_task and schedule_age >= 0 and schedule_age + (old_task['lastcrawltime'] or 0) < now:
             restart = True
         elif _schedule.get('force_update'):
             restart = True


### PR DESCRIPTION
The following patch is fix to this bug:

[E 150421 14:59:14 scheduler:448] 'lastcrawltime'
    Traceback (most recent call last):
      File "/home/thestore/prawler.thestoreinternal.com/pyspider-package/pyspider/scheduler/scheduler.py", line 443, in run
        self.run_once()
      File "/home/thestore/prawler.thestoreinternal.com/pyspider-package/pyspider/scheduler/scheduler.py", line 429, in run_once
        self._check_request()
      File "/home/thestore/prawler.thestoreinternal.com/pyspider-package/pyspider/scheduler/scheduler.py", line 262, in _check_request
        task = self.on_old_request(task, oldtask)
      File "/home/thestore/prawler.thestoreinternal.com/pyspider-package/pyspider/scheduler/scheduler.py", line 579, in on_old_request
        elif schedule_age >= 0 and schedule_age + (old_task['lastcrawltime'] or 0) < now:
    KeyError: 'lastcrawltime'

The situation appears when:
1. Task in status active and still not processed (lastcrawltime not exists)
2. New url arrived with same TaskID with age setted.