### PR TITLE
Improve UI: Providing different way of Creating Projects

### DIFF
--- a/pyspider/webui/static/index.css
+++ b/pyspider/webui/static/index.css
@@ -106,3 +106,26 @@ h1 {
   margin-top: -5px;
   padding: 0 60px 10px 10px;
 }
+.project-create-my .label{
+  color: #000;
+}
+.project-create-my .input-xlarge{
+  display: block;
+  width: 75%;
+  height: 36px;
+  padding: 6px 12px;
+  font-size: 14px;
+  color: #555;
+  background-color: #fff;
+  background-image: none;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  line-height: 1.42857143;
+}
+
+.project-create-my .modal-label{
+  display: inline-block;
+  max-width: 100%;
+  margin-bottom: 5px;
+  font-weight: 700;
+}

--- a/pyspider/webui/static/index.js
+++ b/pyspider/webui/static/index.js
@@ -54,9 +54,20 @@ $(function() {
   });
 
   $('.project-create').on('click', function() {
-    var result = prompt('Create new project:');
-    if (result && result.search(/[^\w]/) == -1) {
-      location.href = "/debug/"+result;
+    var formData = $('form').serializeArray();
+    console.log(formData);
+    var project = formData[0].value;
+    if (project && project.search(/[^\w]/) == -1) {
+      $.ajax({
+          type: "POST",
+          url: location.pathname+'create',
+          data: {
+            'name': project,
+            'target': formData[1].value,
+            'group': formData[2].value
+          }
+        });
+      location.href = "/debug/"+project;
     } else {
       alert('project name not allowed!');
     }

--- a/pyspider/webui/templates/index.html
+++ b/pyspider/webui/templates/index.html
@@ -47,6 +47,38 @@
         </tr>
       </table>
     </header>
+
+    <section>
+      <div class="modal fade" id="confirm-create" tabindex="-1" role="dialog" aria-labelledby="create-dialog" aria-hidden="true">
+        <div class="modal-dialog">
+          <div class="modal-content">
+          
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+              <h4 class="modal-title">Create New Project</h4>
+            </div>
+        
+            <div class="modal-body">
+              <form class="project-create-my" name="create">
+                <label class="modal-label" for="project">Project Name</label><br>
+                <input class="input-xlarge" type="text" name="name"><br>
+                <label class="modal-label" for="target-site">Target website</label><br>
+                <input class="input-xlarge" type="email" name="site"><br>
+                <label class="modal-label" for="pyspider-grouping">Grouping</label><br>
+                <input class="input-xlarge" type="text" name="grouping"><br>
+              </form>
+              <p class="debug-url"></p>
+            </div>
+            
+            <div class="modal-footer">
+              <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+              <a class="project-create btn btn-ok btn-primary">Create</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <section>
       <table class="table sortable-theme-bootstrap projects">
         <thead>
@@ -129,7 +161,9 @@
           {% endif %}
         </div>
         <div class="pull-right">
-          <button class="project-create btn btn-default btn-primary">Create</button>
+          <button class="btn btn-default btn-primary" data-toggle="modal" data-target="#confirm-create">
+            Create
+          </button>
         </div>
       </div>
     </section>
@@ -139,5 +173,3 @@
     <script src="{{ url_for('static', filename='index.js') }}"></script>
   </body>
 </html>
-<!-- vim: set et sw=2 ts=2 sts=2 ff=unix fenc=utf8 syntax=htmldjango: -->
-

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -401,3 +401,20 @@ class TestWebUI(unittest.TestCase):
     def test_x50_tasks(self):
         rv = self.app.get('/tasks')
         self.assertEqual(rv.status_code, 502)
+
+    def test_index_create_prompt_exists(self):
+        rv = self.app.get('/')
+        self.assertEqual(rv.status_code, 200)
+        self.assertIn(b'Project Name', rv.data)
+        self.assertIn(b'Target website', rv.data)
+        self.assertIn(b'Grouping', rv.data)
+        self.assertIn(b'id="confirm-create"', rv.data)
+    
+    def test_index_posts_to_create_path(self):
+        rv = self.app.post('/create', data={
+            'name': "Test-project",
+            'target': "www.This-Does-Not-Matter-Yet.com",
+            'group': "Group of Winners"
+        }))
+        self.assertEqual(rv.status_code, 200)
+        self.assertIn(b'project-create', rv.data)


### PR DESCRIPTION
Hello!

I wanted to submit a small UI improvement to the create button portion. Feel free to be critical and brash :-) 

Note that now hitting create should automatically create a project. I was initially confused when I had to hit save to actually create a project. 

Added two more fields in addition to name. 
* **Project Name** - name to be assigned
* **Target Website** - No real use yet; want this to eventually auto-populate the target website within the script.
* **Grouping** - adds project to that specific group

-*Note* I did this work a month ago, and just recently fast forwarded up to this point in history. Everything still seems to work as expected. 
-Vlad