### PR TITLE
correct links in tutorial

### DIFF
--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -3,8 +3,8 @@ pyspider Tutorial
 
 > The best way to learn how to scrap is learning how to make it.
 
-* [Level 1: HTML and CSS Selector](tutorial/HTML-and-CSS-Selector)
-* [Level 2: AJAX and More HTTP](tutorial/AJAX-and-more-HTTP)
-* [Level 3: Render with PhantomJS](tutorial/Render-with-PhantomJS)
+* [Level 1: HTML and CSS Selector](HTML-and-CSS-Selector)
+* [Level 2: AJAX and More HTTP](AJAX-and-more-HTTP)
+* [Level 3: Render with PhantomJS](Render-with-PhantomJS)
 
 If you have problem using pyspider, [user group](https://groups.google.com/group/pyspider-users) is a place for discussing.


### PR DESCRIPTION
links in http://docs.pyspider.org/en/latest/tutorial/ doesn't work. Seems like file structure changed, so I update the links here