### PR TITLE
fix dump error while using pymongo

### DIFF
--- a/pyspider/database/mongodb/resultdb.py
+++ b/pyspider/database/mongodb/resultdb.py
@@ -23,6 +23,7 @@ class ResultDB(SplitTableMixin, BaseResultDB):
         self._list_project()
 
     def _parse(self, data):
+        data['_id'] = str(data['_id'])
         if 'result' in data:
             data['result'] = json.loads(data['result'])
         return data

--- a/pyspider/webui/result.py
+++ b/pyspider/webui/result.py
@@ -39,7 +39,7 @@ def dump_result(project, _format):
         return "no such project.", 404
 
     offset = int(request.args.get('offset', 0))
-    limit = int(request.args.get('limit', 0)) or None
+    limit = int(request.args.get('limit', 0))
     results = resultdb.select(project, offset=offset, limit=limit)
 
     if _format == 'json':


### PR DESCRIPTION
error occurs when I dump resultdb, my env: win8  pymongo (2.8.1)
```
[I 150819 09:00:15 _internal:87] 127.0.0.1 - - [19/Aug/2015 09:00:15] "GET /results/dump/baidu.json HTTP/1.1" 500 -
[E 150819 09:00:15 _internal:87] Error on request:
    Traceback (most recent call last):
      File "C:\Python27\lib\site-packages\werkzeug\serving.py", line 180, in run_wsgi
        execute(self.server.app)
      File "C:\Python27\lib\site-packages\werkzeug\serving.py", line 170, in execute
        for data in application_iter:
      File "C:\Python27\lib\site-packages\werkzeug\wsgi.py", line 693, in __next__
        return self._next()
      File "C:\Python27\lib\site-packages\werkzeug\wrappers.py", line 81, in _iter_encoded
        for item in iterable:
      File "C:\Python27\lib\site-packages\pyspider-0.3.6-py2.7.egg\pyspider\libs\result_dump.py", line 50, in dump_as_js
on
        for result in results:
      File "C:\Python27\lib\site-packages\pyspider-0.3.6-py2.7.egg\pyspider\database\mongodb\resultdb.py", line 53, in s
elect
        for result in self.database[collection_name].find(fields=fields, skip=offset, limit=limit):
      File "C:\Python27\lib\site-packages\pymongo\collection.py", line 877, in find
        return Cursor(self, *args, **kwargs)
      File "C:\Python27\lib\site-packages\pymongo\cursor.py", line 101, in __init__
        raise TypeError("limit must be an instance of int")
    TypeError: limit must be an instance of int
```
this error come from webui/result.py
```line 42: limit = int(request.args.get('limit', 0)) or None```
limit is always None result to this error.

And another error I found after above fix:
only when dumping as json
`TypeError: ObjectId('xxx') is not JSON serializable`
detial at here http://stackoverflow.com/questions/16586180/typeerror-objectid-is-not-json-serializable
I think the most comfortable fixing is add one line  `data['_id'] = str(data['_id'])` to `ResultDB._parse`


