### PR TITLE
add the missing password  parameter for redis message queue

### DIFF
--- a/pyspider/message_queue/__init__.py
+++ b/pyspider/message_queue/__init__.py
@@ -51,7 +51,9 @@ def connect_message_queue(name, url=None, maxsize=0):
         except:
             db = 0
 
-        return Queue(name, parsed.hostname, parsed.port, db=db, maxsize=maxsize)
+        password = parsed.password or None
+
+        return Queue(name, parsed.hostname, parsed.port, db=db, maxsize=maxsize, password=password)
     else:
         if url.startswith('kombu+'):
             url = url[len('kombu+'):]

--- a/pyspider/message_queue/redis_queue.py
+++ b/pyspider/message_queue/redis_queue.py
@@ -21,7 +21,7 @@ class RedisQueue(object):
     max_timeout = 0.3
 
     def __init__(self, name, host='localhost', port=6379, db=0,
-                 maxsize=0, lazy_limit=True):
+                 maxsize=0, lazy_limit=True, password=None):
         """
         Constructor for RedisQueue
 
@@ -31,7 +31,7 @@ class RedisQueue(object):
                     for better performance.
         """
         self.name = name
-        self.redis = redis.StrictRedis(host=host, port=port, db=db)
+        self.redis = redis.StrictRedis(host=host, port=port, db=db, password=password)
         self.maxsize = maxsize
         self.lazy_limit = lazy_limit
         self.last_qsize = 0


### PR DESCRIPTION
Now, we can use `redis://:passwd@localhost:6379/0` to connect a redis instance that need password.