### PR TITLE
crawl_config will merge with kwargs parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.idea

--- a/pyspider/libs/base_handler.py
+++ b/pyspider/libs/base_handler.py
@@ -276,7 +276,13 @@ class BaseHandler(object):
                 'use_gzip',
         ):
             if key in kwargs:
-                fetch[key] = kwargs.pop(key)
+                keyValue = kwargs.pop(key)
+                #Merge a key if it's a dict and there is a default dict set in ```crawl_config```
+                if fetch.get(key) and isinstance(keyValue,dict) and isinstance(fetch[key],dict):
+                    fetch[key] = fetch[key].update(keyValue)
+                else:
+                    fetch[key] = keyValue
+
         task['fetch'] = fetch
 
         process = {}


### PR DESCRIPTION
as the disqus(http://disq.us/8okgc6) said. 
if ```crawl_config["key"]``` is a dict, it will  be overwride by the kwargs parameters of  ```crawl```
for example
iI have the following ```crawl_config```
```Python
crawl_config = {
        "headers":{
            "User-Agent": "Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.134 Safari/537.36"
        }
    }
```
and the ```User-Agent``` will be lost if I add a ```Referer``` parameters  in ```crawl```
```Python
self.crawl(fetchUrl,headers = {"Referer": "http://example.com/"}, callback=self.list_page)
```
this commit will merge them.