### PR TITLE
fix the wrong age default value in docs

### DIFF
--- a/docs/apis/self.crawl.md
+++ b/docs/apis/self.crawl.md
@@ -18,7 +18,7 @@ def on_start(self):
 
 the following parameters are optional
 
-* `age` - the period of validity of the task. The page would be regarded as not modified during the period. _default: 0(never recrawl)_ <a name="age" href="#age">¶</a>
+* `age` - the period of validity of the task. The page would be regarded as not modified during the period. _default: -1(never recrawl)_ <a name="age" href="#age">¶</a>
 
 ```python
 @config(age=10 * 24 * 60 * 60)


### PR DESCRIPTION
In scheduler.py

```python
default_schedule = {
        'priority': 0,
        'retries': 3,
        'exetime': 0,
        'age': -1,
        'itag': None,
    }
```

default `age` value is -1.   

and in `on_old_request`  

```python
elif schedule_age >= 0 and schedule_age + (old_task.get('lastcrawltime', 0) or 0) < now:
            restart = True
```

age=0 means always recrawl. 

The document  says,

> age - the term of validity of the task. The page would be regarded as not modified during the term. default: 0(never recrawl)  

that is wrong.
