### PR TITLE
fix Firefox task bar number arger than millions

### DIFF
--- a/pyspider/webui/static/index.css
+++ b/pyspider/webui/static/index.css
@@ -77,7 +77,7 @@ h1 {
 }
 .projects td.project-progress {
   position: relative;
-  min-width: 5%;
+  min-width: 6%;
 }
 .projects td.project-progress.progress-all {
   min-width: 10%;

--- a/pyspider/webui/static/index.less
+++ b/pyspider/webui/static/index.less
@@ -72,7 +72,7 @@ h1 {
 
   td.project-progress {
     position: relative;
-    min-width: 5%;
+    min-width: 6%;
     &.progress-all {
       min-width: 10%;
     }


### PR DESCRIPTION
fix Firefox can not show the task number in the bar if task equal or larger than 7 digital(Millions tasks in a day) chrome has no this problem
I use 22' (1920 * 1080) monitor to test it.