### PR TITLE
change python editor's font to a monospaced font

### DIFF
--- a/pyspider/webui/static/debug.css
+++ b/pyspider/webui/static/debug.css
@@ -130,7 +130,6 @@ body {
   border-radius: 5px 0 0 0;
   padding: 5px 0 3px 0;
   /*box-shadow: 0px 0px 30px @color;*/
-
   overflow: hidden;
 }
 #undo-redo-btn-group:hover {
@@ -305,6 +304,7 @@ body {
 #python-editor .CodeMirror {
   height: 100%;
   padding-bottom: 20px;
+  font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "Source Code Pro", "Lucida Console", "Courier New", "Courier", "monospace";
 }
 #python-log {
   width: 100%;

--- a/pyspider/webui/static/debug.less
+++ b/pyspider/webui/static/debug.less
@@ -319,6 +319,7 @@ body {
   .CodeMirror {
     height: 100%;
     padding-bottom: 20px;
+    font-family: "Monaco", "Menlo", "Ubuntu Mono", "Consolas", "Source Code Pro", "Lucida Console", "Courier New", "Courier", "monospace";
   }
 }
 

--- a/pyspider/webui/static/task.css
+++ b/pyspider/webui/static/task.css
@@ -9,10 +9,10 @@
 .base-info {
   padding: 10px 15px 2px 15px;
   background-color: #f5f5f5;
+  border-bottom: 1px solid #ddd;
 }
 .more-info {
   padding: 10px 15px;
-  border-top: 1px solid #ddd;
 }
 .more-info dd {
   display: block;


### PR DESCRIPTION
In order to edit python code more clearly on web(Align more tidy), change python editor's font to a monospaced font