### PR TITLE
fix qsize NotImplementedError on Mac OS X

### DIFF
--- a/pyspider/libs/base_queue.py
+++ b/pyspider/libs/base_queue.py
@@ -84,6 +84,10 @@ class MultiProcessingQueue(MPQueue, object):
         """ Reliable implementation of multiprocessing.Queue.qsize() """
         return self.size.value
 
+    def qsize(self):
+        """ Reliable implementation of multiprocessing.Queue.qsize() """
+        return self.size.value
+
 
 def get_multiprocessing_queue(maxsize=0):
     if hasattr(multiprocessing, 'get_context'):  # python 3.4

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -143,6 +143,7 @@ class TestFetcher(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.text, 'hello')
+        self.assertEqual(self.outqueue.qsize(), 0)
 
     def test_40_with_rpc(self):
         request = copy.deepcopy(self.sample_task_http)


### PR DESCRIPTION
MultiProcessingQueue.qsize is still needed because multiprocessing.Queue have not _qsize but qsize.