### PR TITLE
mongodb add taskid index to taskdb and resultdb

### DIFF
--- a/pyspider/database/mongodb/resultdb.py
+++ b/pyspider/database/mongodb/resultdb.py
@@ -22,6 +22,9 @@ class ResultDB(SplitTableMixin, BaseResultDB):
         self.projects = set()
 
         self._list_project()
+        for project in self.projects:
+            collection_name = self._collection_name(project)
+            self.database[collection_name].ensure_index('taskid')
 
     def _parse(self, data):
         data['_id'] = str(data['_id'])

--- a/pyspider/database/mongodb/taskdb.py
+++ b/pyspider/database/mongodb/taskdb.py
@@ -26,6 +26,7 @@ class TaskDB(SplitTableMixin, BaseTaskDB):
         for project in self.projects:
             collection_name = self._collection_name(project)
             self.database[collection_name].ensure_index('status')
+            self.database[collection_name].ensure_index('taskid')
 
     def _parse(self, data):
         if '_id' in data:


### PR DESCRIPTION
It would speed scheduler/result_worker up very much by adding taskid index as default.

Without creating index default, I have to excute below js everytime when one add a new project:
```
use 'taskdb';
var collectionNames = db.getCollectionNames();
for (var i=0; i< collectionNames.length; i++ ) {
    db.getCollection(collectionNames[i]).ensureIndex( { taskid : 1 } );
}
```
