### PR TITLE
fix bug for mongodb admin permissions multi database

### DIFF
--- a/pyspider/database/__init__.py
+++ b/pyspider/database/__init__.py
@@ -110,6 +110,8 @@ def _connect_database(url):  # NOQA
         parames = {}
         if parsed.path.strip('/'):
             parames['database'] = parsed.path.strip('/')
+            pos = url.rindex('/')
+            url = url[:pos]
 
         if dbtype == 'taskdb':
             from .mongodb.taskdb import TaskDB


### PR DESCRIPTION
When mongodb permissions for admin, mongodb uri not specify a specific database.