### PR TITLE
fix webdav on windows

### DIFF
--- a/pyspider/webui/webdav.py
+++ b/pyspider/webui/webdav.py
@@ -166,8 +166,9 @@ class ScriptProvider(DAVProvider):
         return "pyspiderScriptProvider"
 
     def getResourceInst(self, path, environ):
-        path = os.path.normpath(path)
+        path = os.path.normpath(path).replace('\\', '/')
         if path in ('/', '.', ''):
+            path = '/'
             return RootCollection(path, environ, self.app)
         else:
             return ScriptResource(path, environ, self.app)


### PR DESCRIPTION
1.`os.path.normpath(path)` would convert `/` to `\\` on windows.
2.`windows map network driver` would access with path  `.`, 
but there is : `assert path=="" or path.startswith("/")` check in wsgidav. 
So `path = '/' if path in ('/', '.', '')`