### PR TITLE
Update Database classes in sqlalchemy to use 'pool_recycle'

### DIFF
--- a/pyspider/database/sqlalchemy/projectdb.py
+++ b/pyspider/database/sqlalchemy/projectdb.py
@@ -38,14 +38,14 @@ class ProjectDB(BaseProjectDB):
             database = self.url.database
             self.url.database = None
             try:
-                engine = create_engine(self.url)
+                engine = create_engine(self.url, pool_recycle=3600)
                 conn = engine.connect()
                 conn.execute("commit")
                 conn.execute("CREATE DATABASE %s" % database)
             except sqlalchemy.exc.SQLAlchemyError:
                 pass
             self.url.database = database
-        self.engine = create_engine(url)
+        self.engine = create_engine(url, pool_recycle=3600)
         self.table.create(self.engine, checkfirst=True)
 
     @staticmethod

--- a/pyspider/database/sqlalchemy/resultdb.py
+++ b/pyspider/database/sqlalchemy/resultdb.py
@@ -37,12 +37,14 @@ class ResultDB(SplitTableMixin, BaseResultDB):
             database = self.url.database
             self.url.database = None
             try:
-                engine = create_engine(self.url, convert_unicode=True)
+                engine = create_engine(self.url, convert_unicode=True,
+                                       pool_recycle=3600)
                 engine.execute("CREATE DATABASE IF NOT EXISTS %s" % database)
             except sqlalchemy.exc.SQLAlchemyError:
                 pass
             self.url.database = database
-        self.engine = create_engine(url, convert_unicode=True)
+        self.engine = create_engine(url, convert_unicode=True,
+                                    pool_recycle=3600)
 
         self._list_project()
 

--- a/pyspider/database/sqlalchemy/taskdb.py
+++ b/pyspider/database/sqlalchemy/taskdb.py
@@ -43,14 +43,14 @@ class TaskDB(SplitTableMixin, BaseTaskDB):
             database = self.url.database
             self.url.database = None
             try:
-                engine = create_engine(self.url)
+                engine = create_engine(self.url, pool_recycle=3600)
                 conn = engine.connect()
                 conn.execute("commit")
                 conn.execute("CREATE DATABASE %s" % database)
             except sqlalchemy.exc.SQLAlchemyError:
                 pass
             self.url.database = database
-        self.engine = create_engine(url)
+        self.engine = create_engine(url, pool_recycle=3600)
 
         self._list_project()
 


### PR DESCRIPTION
while use mysql+sqlalchemy, if the system idle more than 8 hours, will raise Exception
```
sqlalchemy.exc.OperationalError: (mysql.connector.errors.OperationalError) MySQL Connection not available. [SQL: 'SELECT projectdb.name, projectdb.`group` \nFROM projectdb \nWHERE projectdb.name = %(name_1)s \n LIMIT %(param_1)s']
```

use  `pool_recycle` while `creat_engine` to resolve the problem