### PR TITLE
ZeroDivisionError when int(min_tick) == 0

### DIFF
--- a/pyspider/scheduler/scheduler.py
+++ b/pyspider/scheduler/scheduler.py
@@ -424,7 +424,7 @@ class Scheduler(object):
                 continue
             if project.waiting_get_info:
                 continue
-            if project.min_tick == 0:
+            if int(project.min_tick) == 0:
                 continue
             if self._last_tick % int(project.min_tick) != 0:
                 continue


### PR DESCRIPTION
In some rare occasions, some users may use some "illegal" float values for their cron_job function. For example,

```
@every(seconds=0.1)
def on_start(self):
    ...
```

Then the `project.min_tick` will be `0.1` which will lead to a `ZeroDivisionError` when scheduler is doing `_check_cronjob` ([Line 429 of `scheduler.py`](https://github.com/binux/pyspider/blob/master/pyspider/scheduler/scheduler.py#L429)):

```
...
if self._last_tick % int(project.min_tick) != 0:
    continue
...
```
