### PR TITLE
fix install error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,9 @@ setup(
         'pyspider': [
             'logging.conf',
             'fetcher/phantomjs_fetcher.js',
-            'webui/static/*',
+            'fetcher/splash_fetcher.lua',
+            'webui/static/*.js',
+            'webui/static/*.css',
             'webui/templates/*'
         ],
     },


### PR DESCRIPTION
1.  `webui/static/src` would be considered as a file and cause install error, so limit to *.css and *.js files.

2.  add missing `fetcher/splash_fetcher.lua`