### PR TITLE
fix "pyspider/webui/index.py:12: ExtDeprecationWarning: Importing flask.ext.login is deprecated, use flask_login instead"

### DIFF
--- a/pyspider/webui/debug.py
+++ b/pyspider/webui/debug.py
@@ -13,7 +13,11 @@ import inspect
 import datetime
 import traceback
 from flask import render_template, request, json
-from flask.ext import login
+
+try:
+    import flask_login as login
+except ImportError:
+    from flask.ext import login
 
 from pyspider.libs import utils, sample_handler, dataurl
 from pyspider.libs.response import rebuild_response

--- a/pyspider/webui/index.py
+++ b/pyspider/webui/index.py
@@ -9,7 +9,12 @@ import socket
 
 from six import iteritems, itervalues
 from flask import render_template, request, json
-from flask.ext import login
+
+try:
+    import flask_login as login
+except ImportError:
+    from flask.ext import login
+
 from .app import app
 
 index_fields = ['name', 'group', 'status', 'comments', 'rate', 'burst', 'updatetime']


### PR DESCRIPTION
 flask.ext.login is deprecated
![image](https://cloud.githubusercontent.com/assets/423077/22049553/08b28d64-dd6f-11e6-9c46-342f6f8acd73.png)
