### PR TITLE
tblib is required  for pyspider/libs/response.py#L15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ redis
 kombu
 psycopg2
 elasticsearch
+tblib


### PR DESCRIPTION
https://github.com/binux/pyspider/blob/master/pyspider/libs/response.py#L15

![image](https://cloud.githubusercontent.com/assets/423077/22051977/048605aa-dd82-11e6-9796-38ded44974d5.png)
