### PR TITLE
Fix add CSS selector to editor

### DIFF
--- a/pyspider/webui/static/src/debug.js
+++ b/pyspider/webui/static/src/debug.js
@@ -58,11 +58,12 @@ window.SelectorHelper = (function() {
     return pattern.trim();
   }
 
+  var current_path = null;
   function selector_changed(path) {
+    current_path = path;
     server.heightlight(merge_pattern(path));
   }
   
-  var current_path = null;
   function render_selector_helper(path) {
     helper.find('.element').remove();
     var elements = [];


### PR DESCRIPTION
The variable `current_path` needs to be set when selecting an element.