### PR TITLE
support redis 3.x in cluster mode for message queue

### DIFF
--- a/docs/Command-Line.md
+++ b/docs/Command-Line.md
@@ -94,6 +94,7 @@ beanstalk:
     beanstalk://host:11300/
 redis:
     redis://host:6379/db
+    redis://host1:port1,host2:port2,...,hostn:portn (for redis 3.x in cluster mode)
 kombu:
     kombu+transport://userid:password@hostname:port/virtual_host
     see http://kombu.readthedocs.org/en/latest/userguide/connections.html#urls

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -85,6 +85,7 @@ beanstalk:
     beanstalk://host:11300/
 redis:
     redis://host:6379/db
+    redis://host1:port1,host2:port2,...,hostn:portn (for redis 3.x in cluster mode)
 builtin:
     None
 ```

--- a/pyspider/message_queue/redis_queue.py
+++ b/pyspider/message_queue/redis_queue.py
@@ -21,7 +21,7 @@ class RedisQueue(object):
     max_timeout = 0.3
 
     def __init__(self, name, host='localhost', port=6379, db=0,
-                 maxsize=0, lazy_limit=True, password=None):
+                 maxsize=0, lazy_limit=True, password=None, cluster_nodes=None):
         """
         Constructor for RedisQueue
 
@@ -31,7 +31,11 @@ class RedisQueue(object):
                     for better performance.
         """
         self.name = name
-        self.redis = redis.StrictRedis(host=host, port=port, db=db, password=password)
+        if(cluster_nodes is not None):
+            from rediscluster import StrictRedisCluster
+            self.redis = StrictRedisCluster(startup_nodes=cluster_nodes)
+        else:
+            self.redis = redis.StrictRedis(host=host, port=port, db=db, password=password)
         self.maxsize = maxsize
         self.lazy_limit = lazy_limit
         self.last_qsize = 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ SQLAlchemy>=0.9.7
 six>=1.5.0
 amqp>=1.3.0,<2.0
 redis
+redis-py-cluster
 kombu
 psycopg2
 elasticsearch

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ extras_require_all = [
     'pymongo>=2.7.2',
     'SQLAlchemy>=0.9.7',
     'redis',
+    'redis-py-cluster',
     'psycopg2',
     'elasticsearch>=2.0.0,<2.4.0',
 ]


### PR DESCRIPTION
The default redis package is not supported in the cluster mode. So ... it may helps for who deploy pyspider with redis cluster.
It has been tested and works well in production environment with redis 3.x of **cluster** mode.
Then the config template can be 
```
redis:
    redis://host:6379/db
    or
    redis://host1:port1,host2:port2,...,hostn:portn (for redis 3.x in cluster mode)
```
ex. (3 master & 3 slave as my development environment )
```
url='redis://10.78.155.61:16340,10.78.155.67:16340,10.78.155.68:16340,10.78.155.70:16340,10.78.155.71:16340,10.78.155.72:16340'
```
