### PR TITLE
mongodb操作优化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.py[cod]
 data/*
-
+.venv
+.idea
 # C extensions
 *.so
 

--- a/pyspider/database/mongodb/resultdb.py
+++ b/pyspider/database/mongodb/resultdb.py
@@ -7,7 +7,9 @@
 
 import json
 import time
+
 from pymongo import MongoClient
+
 from pyspider.database.base.resultdb import ResultDB as BaseResultDB
 from .mongodbbase import SplitTableMixin
 
@@ -22,9 +24,12 @@ class ResultDB(SplitTableMixin, BaseResultDB):
         self.projects = set()
 
         self._list_project()
-        for project in self.projects:
-            collection_name = self._collection_name(project)
-            self.database[collection_name].ensure_index('taskid')
+        # we suggest manually build index in advance, instead of indexing
+        #  in the startup process,
+        # for project in self.projects:
+        #     collection_name = self._collection_name(project)
+        #     self.database[collection_name].ensure_index('taskid')
+        pass
 
     def _create_project(self, project):
         collection_name = self._collection_name(project)
@@ -47,9 +52,9 @@ class ResultDB(SplitTableMixin, BaseResultDB):
             self._create_project(project)
         collection_name = self._collection_name(project)
         obj = {
-            'taskid': taskid,
-            'url': url,
-            'result': result,
+            'taskid'    : taskid,
+            'url'       : url,
+            'result'    : result,
             'updatetime': time.time(),
         }
         return self.database[collection_name].update(


### PR DESCRIPTION
# 1、去掉连接后ensure_index操作
>  当result、task 表数据量较大时，启动后建索引会等待很长时间，尤其是分布式部署情况下，每个进程启动后都会重建索引

# 2、优化taskdb stat_count操作
> aggregate做分组统计时进行全表扫描，比较慢，实际项目种导致scheduler模块启动时长接近30min，
> 考虑到status字段有索引，直接进行count统计反而效果比较好
> 实测效果优于aggregate操作

