### PR TITLE
update pyspider work on tornado5.0

### DIFF
--- a/pyspider/fetcher/tornado_fetcher.py
+++ b/pyspider/fetcher/tornado_fetcher.py
@@ -87,14 +87,13 @@ class Fetcher(object):
         self._quit = False
         self.proxy = proxy
         self.async = async
-        self.ioloop = tornado.ioloop.IOLoop()
+        self.ioloop = tornado.ioloop.IOLoop.current()
 
         self.robots_txt_cache = {}
 
         # binding io_loop to http_client here
         if self.async:
-            self.http_client = MyCurlAsyncHTTPClient(max_clients=self.poolsize,
-                                                     io_loop=self.ioloop)
+            self.http_client = MyCurlAsyncHTTPClient(max_clients=self.poolsize)
         else:
             self.http_client = tornado.httpclient.HTTPClient(MyCurlAsyncHTTPClient, max_clients=self.poolsize)
 
@@ -659,8 +658,8 @@ class Fetcher(object):
                     logger.exception(e)
                     break
 
-        tornado.ioloop.PeriodicCallback(queue_loop, 100, io_loop=self.ioloop).start()
-        tornado.ioloop.PeriodicCallback(self.clear_robot_txt_cache, 10000, io_loop=self.ioloop).start()
+        tornado.ioloop.PeriodicCallback(queue_loop, 100).start()
+        tornado.ioloop.PeriodicCallback(self.clear_robot_txt_cache, 10000).start()
         self._running = True
 
         try:
@@ -711,8 +710,8 @@ class Fetcher(object):
         import tornado.httpserver
 
         container = tornado.wsgi.WSGIContainer(application)
-        self.xmlrpc_ioloop = tornado.ioloop.IOLoop()
-        self.xmlrpc_server = tornado.httpserver.HTTPServer(container, io_loop=self.xmlrpc_ioloop)
+        self.xmlrpc_ioloop = tornado.ioloop.IOLoop.current()
+        self.xmlrpc_server = tornado.httpserver.HTTPServer(container)
         self.xmlrpc_server.listen(port=port, address=bind)
         logger.info('fetcher.xmlrpc listening on %s:%s', bind, port)
         self.xmlrpc_ioloop.start()

--- a/pyspider/scheduler/scheduler.py
+++ b/pyspider/scheduler/scheduler.py
@@ -776,8 +776,8 @@ class Scheduler(object):
         import tornado.httpserver
 
         container = tornado.wsgi.WSGIContainer(application)
-        self.xmlrpc_ioloop = tornado.ioloop.IOLoop()
-        self.xmlrpc_server = tornado.httpserver.HTTPServer(container, io_loop=self.xmlrpc_ioloop)
+        self.xmlrpc_ioloop = tornado.ioloop.IOLoop.current()
+        self.xmlrpc_server = tornado.httpserver.HTTPServer(container)
         self.xmlrpc_server.listen(port=port, address=bind)
         logger.info('scheduler.xmlrpc listening on %s:%s', bind, port)
         self.xmlrpc_ioloop.start()
@@ -1141,8 +1141,7 @@ class OneScheduler(Scheduler):
 
     def run(self):
         import tornado.ioloop
-        tornado.ioloop.PeriodicCallback(self.run_once, 100,
-                                        io_loop=self.ioloop).start()
+        tornado.ioloop.PeriodicCallback(self.run_once, 100).start()
         self.ioloop.start()
 
     def quit(self):

--- a/setup.py
+++ b/setup.py
@@ -36,17 +36,17 @@ install_requires = [
 if sys.version_info < (2, 7):  # 2.6
     install_requires.extend([
         'wsgidav<2.0.0',
-        'tornado>=3.2,<4.5',
+        'tornado>=5.0',
     ])
 elif sys.version_info >= (3, 0):  # 3.*
     install_requires.extend([
         'wsgidav>=2.0.0',
-        'tornado>=3.2',
+        'tornado>=5.0',
     ])
 else:  # 2.7
     install_requires.extend([
         'wsgidav',
-        'tornado>=3.2',
+        'tornado>=5.0',
     ])
 
 extras_require_all = [


### PR DESCRIPTION
python环境中，默认`tornado`版本是最新的`5.0`，在`4.1`之后就废弃了`io_loop`参数。
更新`pyspider`各使用`io_loop`的接口。
如下：
1. `MyCurlAsyncHTTPClient(CurlAsyncHTTPClient)`
2. `tornado.httpserver.HTTPServer`
3. `tornado.ioloop.PeriodicCallback`