### PR TITLE
Fix mysql return bytes as field name type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
     - psql -c "CREATE DATABASE pyspider_test_resultdb ENCODING 'UTF8' TEMPLATE=template0;" -U postgres
     - sleep 10
 install:
-    - pip install http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-2.0.4.zip#md5=3df394d89300db95163f17c843ef49df
+    - pip install mysql-connector-python
     - pip install https://github.com/marcus67/easywebdav/archive/master.zip
     - pip install --no-use-wheel lxml
     - pip install --allow-all-external -e .[all,test]

--- a/pyspider/database/basedb.py
+++ b/pyspider/database/basedb.py
@@ -11,6 +11,7 @@ import logging
 logger = logging.getLogger('database.basedb')
 
 from six import itervalues
+from pyspider.libs import utils
 
 
 class BaseDB:
@@ -72,7 +73,10 @@ class BaseDB:
         logger.debug("<sql: %s>", sql_query)
 
         dbcur = self._execute(sql_query, where_values)
-        fields = [f[0] for f in dbcur.description]
+
+        # f[0] may return bytes type
+        # https://github.com/mysql/mysql-connector-python/pull/37
+        fields = [utils.text(f[0]) for f in dbcur.description]
 
         for row in dbcur:
             yield dict(zip(fields, row))

--- a/pyspider/database/mysql/mysqlbase.py
+++ b/pyspider/database/mysql/mysqlbase.py
@@ -17,6 +17,8 @@ class MySQLMixin(object):
         try:
             if self.conn.unread_result:
                 self.conn.get_rows()
+                if hasattr(self.conn, 'free_result'):
+                    self.conn.free_result()
             return self.conn.cursor()
         except (mysql.connector.OperationalError, mysql.connector.InterfaceError):
             self.conn.ping(reconnect=True)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -72,7 +72,7 @@ class TestRun(unittest.TestCase):
         self.assertEqual(ctx.obj.debug, True)
 
         import mysql.connector
-        with self.assertRaises(mysql.connector.InterfaceError):
+        with self.assertRaises(mysql.connector.Error):
             ctx.obj.taskdb
 
         with self.assertRaises(Exception):


### PR DESCRIPTION
This fix different behavior of `mysql-connector-python` C extension and pure python version.

Fix #758 #766 

**How to repeat:**

Install mysql, pyspider, then install `mysql-connector-python` via `pip` :

```bash
pip install mysql-connector-python  # current version 8.0.11
```

Run python script:

```python
from pyspider.database.mysql.taskdb import TaskDB

db = TaskDB(user='root', database='db', passwd='password')
print(db.get_task('projectname', 'taskid'))
```

and output:

```
{'taskid': 'taskid',
 'project': 'project',
 'url': 'url',
 'status': 1,
 b'schedule': '{"itag": "v2", "age": 86400}',    // <- b'schedule' but expect 'schedule'
 b'fetch': None,
 b'process': None,
 b'track': None,
 'lastcrawltime': None,
 'updatetime': None}
```

Related: https://github.com/mysql/mysql-connector-python/pull/37