### PR TITLE
optimise scheduler select limit and task queue

### DIFF
--- a/pyspider/scheduler/scheduler.py
+++ b/pyspider/scheduler/scheduler.py
@@ -477,7 +477,10 @@ class Scheduler(object):
         cnt = 0
         cnt_dict = dict()
         limit = self.LOOP_LIMIT
-        for project in itervalues(self.projects):
+
+        # dynamic assign select limit for each project, use qsize as weight
+        project_weights, total_weight = dict(), 0
+        for project in itervalues(self.projects):  # type:Project
             if not project.active:
                 continue
             # only check project pause when select new tasks, cronjob and new request still working
@@ -485,16 +488,40 @@ class Scheduler(object):
                 continue
             if project.waiting_get_info:
                 continue
+
+            # task queue
+            task_queue = project.task_queue  # type:TaskQueue
+            pro_weight = task_queue.size()
+            total_weight += pro_weight
+            project_weights[project.name] = pro_weight
+            pass
+
+        min_project_limit = int(limit / 10.)  # ensure minimum select limit for each project
+        max_project_limit = int(limit / 3.0)  # ensure maximum select limit for each project
+
+        for pro_name, pro_weight in iteritems(project_weights):
             if cnt >= limit:
                 break
+
+            project = self.projects[pro_name]  # type:Project
 
             # task queue
             task_queue = project.task_queue
             task_queue.check_update()
             project_cnt = 0
 
+            # calculate select limit for project
+            if total_weight < 1 or pro_weight < 1:
+                project_limit = min_project_limit
+            else:
+                project_limit = int((1.0 * pro_weight / total_weight) * limit)
+                if project_limit < min_project_limit:
+                    project_limit = min_project_limit
+                elif project_limit > max_project_limit:
+                    project_limit = max_project_limit
+
             # check send_buffer here. when not empty, out_queue may blocked. Not sending tasks
-            while cnt < limit and project_cnt < limit / 10:
+            while cnt < limit and project_cnt < project_limit:
                 taskid = task_queue.get()
                 if not taskid:
                     break

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -45,14 +45,14 @@ class TestTaskQueue(unittest.TestCase):
 
     def test_40_time_queue_1(self):
         self.task_queue.check_update()
-        self.assertEqual(self.task_queue.get(), 'a3')
+        self.assertEqual(self.task_queue.get(), 'a1')
         self.assertEqual(self.task_queue.size(), 4)
 
     def test_50_time_queue_2(self):
         time.sleep(0.3)
         self.task_queue.check_update()
         self.assertEqual(self.task_queue.get(), 'a4')
-        self.assertEqual(self.task_queue.get(), 'a1')
+        self.assertEqual(self.task_queue.get(), 'a3')
         self.assertEqual(self.task_queue.size(), 4)
 
     def test_60_processing_queue(self):

--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import Queue
+import unittest
+
+import six
+
+from pyspider.scheduler.task_queue import InQueueTask, TaskQueue
+
+
+class TestTaskQueue(unittest.TestCase):
+    """
+        TestTaskQueue
+    """
+
+    def test_task_queue_in_time_order(self):
+        tq = TaskQueue(rate=300, burst=1000)
+
+        queues = dict()
+        tasks = dict()
+
+        for i in range(0, 100):
+            it = InQueueTask(str(i), priority=i / 10, exetime=0)
+            tq.put(it.taskid, it.priority, it.exetime)
+
+            if it.priority not in queues:
+                queues[it.priority] = Queue.Queue()
+
+            q = queues[it.priority]  # type:Queue.Queue
+            q.put(it)
+            tasks[it.taskid] = it
+
+            six.print_('put, ', it)
+
+        for i in range(0, 100):
+            task_id = tq.get()
+            task = tasks[task_id]
+            q = queues[task.priority]  # type: Queue.Queue
+            expect_task = q.get()
+            self.assertEqual(task_id, expect_task.taskid)
+            self.assertEqual(task.priority, 9 - i / 10)
+            six.print_('get, ', task)
+
+        self.assertEqual(tq.priority_queue.qsize(), 0)
+        self.assertEqual(tq.processing.qsize(), 100)
+        for q in six.itervalues(queues):  # type:Queue.Queue
+            self.assertEqual(q.qsize(), 0)
+        pass
+
+    pass
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
1、dynamic assign select-limit for each project based on its task queue size;
2、optimise task queue to solve the probleam that , in case of continuous big request flow, priority queue using heap sort for tasks with  the same priority and exetime=0 behave more like a FILO stack but not a FIFO queue.
