### PR TITLE
optimise scheluler dynamic select limit and improve task queue 

### DIFF
--- a/pyspider/scheduler/scheduler.py
+++ b/pyspider/scheduler/scheduler.py
@@ -477,7 +477,10 @@ class Scheduler(object):
         cnt = 0
         cnt_dict = dict()
         limit = self.LOOP_LIMIT
-        for project in itervalues(self.projects):
+
+        # dynamic assign select limit for each project, use qsize as weight
+        project_weights, total_weight = dict(), 0
+        for project in itervalues(self.projects):  # type:Project
             if not project.active:
                 continue
             # only check project pause when select new tasks, cronjob and new request still working
@@ -485,16 +488,40 @@ class Scheduler(object):
                 continue
             if project.waiting_get_info:
                 continue
+
+            # task queue
+            task_queue = project.task_queue  # type:TaskQueue
+            pro_weight = task_queue.size()
+            total_weight += pro_weight
+            project_weights[project.name] = pro_weight
+            pass
+
+        min_project_limit = int(limit / 10.)  # ensure minimum select limit for each project
+        max_project_limit = int(limit / 3.0)  # ensure maximum select limit for each project
+
+        for pro_name, pro_weight in iteritems(project_weights):
             if cnt >= limit:
                 break
+
+            project = self.projects[pro_name]  # type:Project
 
             # task queue
             task_queue = project.task_queue
             task_queue.check_update()
             project_cnt = 0
 
+            # calculate select limit for project
+            if total_weight < 1 or pro_weight < 1:
+                project_limit = min_project_limit
+            else:
+                project_limit = int((1.0 * pro_weight / total_weight) * limit)
+                if project_limit < min_project_limit:
+                    project_limit = min_project_limit
+                elif project_limit > max_project_limit:
+                    project_limit = max_project_limit
+
             # check send_buffer here. when not empty, out_queue may blocked. Not sending tasks
-            while cnt < limit and project_cnt < limit / 10:
+            while cnt < limit and project_cnt < project_limit:
                 taskid = task_queue.get()
                 if not taskid:
                     break

--- a/pyspider/scheduler/task_queue.py
+++ b/pyspider/scheduler/task_queue.py
@@ -5,10 +5,11 @@
 #         http://binux.me
 # Created on 2014-02-07 13:12:10
 
-import time
 import heapq
 import logging
 import threading
+import time
+
 try:
     from UserDict import DictMixin
 except ImportError:
@@ -38,17 +39,23 @@ class InQueueTask(DictMixin):
         self.exetime = exetime
 
     def __cmp__(self, other):
-        if self.exetime == 0 and other.exetime == 0:
-            return -cmp(self.priority, other.priority)
-        else:
+        # compare priority first
+        cmp_priority = -cmp(self.priority, other.priority)
+
+        # when two element have the same priority, then compare exetime.
+        # keep tasks in time order.
+        if cmp_priority == 0:
             return cmp(self.exetime, other.exetime)
+        return cmp_priority
 
     def __lt__(self, other):
         return self.__cmp__(other) < 0
 
+    def __repr__(self):
+        return repr({k: self[k] for k in self.__slots__})
+
 
 class PriorityTaskQueue(Queue.Queue):
-
     '''
     TaskQueue
 
@@ -66,11 +73,9 @@ class PriorityTaskQueue(Queue.Queue):
         if item.taskid in self.queue_dict:
             task = self.queue_dict[item.taskid]
             changed = False
-            if item.priority > task.priority:
-                task.priority = item.priority
-                changed = True
-            if item.exetime < task.exetime:
-                task.exetime = item.exetime
+            if item < task:
+                task.priority = max(item.priority, task.priority)
+                task.exetime = min(item.exetime, task.exetime)
                 changed = True
             if changed:
                 self._resort()
@@ -113,7 +118,6 @@ class PriorityTaskQueue(Queue.Queue):
 
 
 class TaskQueue(object):
-
     '''
     task queue for scheduler, have a priority queue and a time queue for delayed tasks
     '''
@@ -173,9 +177,26 @@ class TaskQueue(object):
         self.mutex.release()
 
     def put(self, taskid, priority=0, exetime=0):
-        '''Put a task into task queue'''
+        """
+        Put a task into task queue
+        
+        when use heap sort, if we put tasks(with the same priority and exetime=0) into queue,
+        the queue is not a strict FIFO queue, but more like a FILO stack.
+
+        It is very possible that when there are continuous big flow, the speed of select is 
+        slower than request, resulting in priority-queue accumulation in short time.
+        
+        In this scenario, the tasks more earlier entering the priority-queue will not get 
+        processed until the request flow becomes small. 
+        
+        """
         now = time.time()
-        task = InQueueTask(taskid, priority, exetime)
+
+        # give exetime to time.time() by default. So if two or more tasks
+        # have the same priority, we can still keep tasks in time order
+        # as much as possible.
+        task = InQueueTask(taskid, priority, exetime if exetime > 0 else now)
+
         self.mutex.acquire()
         if taskid in self.priority_queue:
             self.priority_queue.put(task)
@@ -190,6 +211,7 @@ class TaskQueue(object):
                 self.time_queue.put(task)
             else:
                 self.priority_queue.put(task)
+
         self.mutex.release()
 
     def get(self):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -45,14 +45,14 @@ class TestTaskQueue(unittest.TestCase):
 
     def test_40_time_queue_1(self):
         self.task_queue.check_update()
-        self.assertEqual(self.task_queue.get(), 'a3')
+        self.assertEqual(self.task_queue.get(), 'a1')
         self.assertEqual(self.task_queue.size(), 4)
 
     def test_50_time_queue_2(self):
         time.sleep(0.3)
         self.task_queue.check_update()
         self.assertEqual(self.task_queue.get(), 'a4')
-        self.assertEqual(self.task_queue.get(), 'a1')
+        self.assertEqual(self.task_queue.get(), 'a3')
         self.assertEqual(self.task_queue.size(), 4)
 
     def test_60_processing_queue(self):

--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+import unittest
+
+import six
+from six.moves import queue as Queue
+
+from pyspider.scheduler.task_queue import InQueueTask, TaskQueue
+
+
+class TestTaskQueue(unittest.TestCase):
+    """
+        TestTaskQueue
+    """
+
+    def test_task_queue_in_time_order(self):
+        tq = TaskQueue(rate=300, burst=1000)
+
+        queues = dict()
+        tasks = dict()
+
+        for i in range(0, 100):
+            it = InQueueTask(str(i), priority=int(i // 10), exetime=0)
+            tq.put(it.taskid, it.priority, it.exetime)
+
+            if it.priority not in queues:
+                queues[it.priority] = Queue.Queue()
+
+            q = queues[it.priority]  # type:Queue.Queue
+            q.put(it)
+            tasks[it.taskid] = it
+
+            six.print_('put, ', it)
+
+        for i in range(0, 100):
+            task_id = tq.get()
+            task = tasks[task_id]
+            q = queues[task.priority]  # type: Queue.Queue
+            expect_task = q.get()
+            self.assertEqual(task_id, expect_task.taskid)
+            self.assertEqual(task.priority, int(9 - i // 10))
+            six.print_('get, ', task)
+
+        self.assertEqual(tq.priority_queue.qsize(), 0)
+        self.assertEqual(tq.processing.qsize(), 100)
+        for q in six.itervalues(queues):  # type:Queue.Queue
+            self.assertEqual(q.qsize(), 0)
+        pass
+
+    pass
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
1. Dynamic calculate select limit for each project when doing _check_select;
2. Improve task queue, keep tasks( with the same priority ) in time order when use heap sort.
- In my project, this heap queue behaves more like a FILO stack when the speed of request faster than select, and this case big problem.
