### PR TITLE
Proposed changes to travis ci file to allow passing builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 language: python
 cache: pip
 python:
-    - "2.6"
     - "2.7"
     - "3.3"
     - "3.4"
@@ -38,8 +37,9 @@ before_script:
 install:
     - pip install mysql-connector-python
     - pip install https://github.com/marcus67/easywebdav/archive/master.zip
-    - pip install --no-use-wheel lxml
-    - pip install --allow-all-external -e .[all,test]
+
+    - if [[ $TRAVIS_PYTHON_VERSION != '3.5' ]]; then pip install --no-use-wheel lxml; else pip install lxml; fi
+    - if [[ $TRAVIS_PYTHON_VERSION != '3.5' ]]; then pip install --allow-all-external -e .[all,test]; else pip install -e .[all,test]; fi
     - pip install coveralls
 script:
     - coverage run setup.py test


### PR DESCRIPTION
Thought I would try updating the travis ci file a bit so that some of the versions pass to let the travis builds pass overall. Looking into the pycparser build issue with 2.6 I found the guy had dropped support for pre 2.7 versions so I think it should be dropped from travis. 

The next bit with 3.5 I'm not entirely sure on so feel free tell me if I'm messing something up. The build for 3.5 fails on the --no-use-wheel also fails on --allow-all-external after that. I think pip had dropped them after version 10. For some reason 3.5 has pip version 18 so I changed the pip install lines to avoid the errors with the parameters being gone. It's build passes with them gone so I think it's okay?

