### PR TITLE
Remove encoding parameter from json.load for Python 3.9 compatibility.

### DIFF
--- a/pyspider/database/mongodb/taskdb.py
+++ b/pyspider/database/mongodb/taskdb.py
@@ -45,7 +45,7 @@ class TaskDB(SplitTableMixin, BaseTaskDB):
                 if data[each]:
                     if isinstance(data[each], bytearray):
                         data[each] = str(data[each])
-                    data[each] = json.loads(data[each], encoding='utf8')
+                    data[each] = json.loads(data[each])
                 else:
                     data[each] = {}
         return data


### PR DESCRIPTION
Fixes #953 