### PR TITLE
fix(sec): upgrade tornado to 5.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ lxml==4.3.3
 pycurl==7.43.0.3
 pyquery==1.4.0
 requests==2.24.0
-tornado==4.5.3
+tornado==5.1
 mysql-connector-python==8.0.16
 pika==1.1.0
 pymongo==3.9.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in tornado 4.5.3
- [CVE-2018-1000518](https://www.oscs1024.com/hd/CVE-2018-1000518)


### What did I do？
Upgrade tornado from 4.5.3 to 5.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS