### PR TITLE
fix(sec): upgrade lxml to 4.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Flask==0.10
 Jinja2==2.7
 chardet==3.0.4
 cssselect==0.9
-lxml==4.3.3
+lxml==4.9.1
 pycurl==7.43.0.3
 pyquery==1.4.0
 requests==2.24.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in lxml 4.3.3
- [MPS-2022-14974](https://www.oscs1024.com/hd/MPS-2022-14974)


### What did I do？
Upgrade lxml from 4.3.3 to 4.9.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>